### PR TITLE
Make webhook able to be deployed to any namespace

### DIFF
--- a/deploy/validating_webhook_config.yaml
+++ b/deploy/validating_webhook_config.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating.approval.tmax.io
@@ -7,10 +7,26 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: approval
 webhooks:
-  - clientConfig:
+  - admissionReviewVersions:
+    - v1beta1
+    - v1
+    clientConfig:
       service:
         name: approval-webhook
         namespace: hypercloud4-system
+        port: 443
+        path: /validate-approvals
     failurePolicy: Fail
     sideEffects: None
     name: validating.approval.tmax.io
+    rules:
+    - apiGroups:
+      - tmax.io
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - approvals/*
+      scope: '*'

--- a/internal/k8s.go
+++ b/internal/k8s.go
@@ -1,0 +1,34 @@
+package internal
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+)
+
+func Namespace() (string, error) {
+	nsPath := "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	if FileExists(nsPath) {
+		// Running in k8s cluster
+		nsBytes, err := ioutil.ReadFile(nsPath)
+		if err != nil {
+			return "", errors.New("could not read file " + nsPath)
+		}
+		return string(nsBytes), nil
+	} else {
+		// Not running in k8s cluster (may be running locally)
+		ns := os.Getenv("NAMESPACE")
+		if ns == "" {
+			ns = "default"
+		}
+		return ns, nil
+	}
+}
+
+func WebhookServiceName() string {
+	svcName := os.Getenv("WEBHOOK_SERVICE_NAME")
+	if svcName == "" {
+		svcName = "approval-webhook"
+	}
+	return svcName
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,0 +1,11 @@
+package internal
+
+import "os"
+
+func FileExists(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/pkg/webhook/approval/approval.go
+++ b/pkg/webhook/approval/approval.go
@@ -14,13 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	certResources "knative.dev/pkg/webhook/certificates/resources"
+
+	"approval-operator/internal"
 )
 
 const (
 	DefaultPort          = 443
 	CertDir              = "/tmp/approval-webhook"
-	Namespace            = "approval"
-	ServiceName          = "approval-webhook"
 	ValidationPath       = "/validate-approvals"
 	ValidationConfigName = "validating.approval.tmax.io"
 )
@@ -48,8 +48,15 @@ func CreateCert(ctx context.Context, client client.Client) error {
 		return err
 	}
 
+	// Get service name and namespace
+	svc := internal.WebhookServiceName()
+	ns, err := internal.Namespace()
+	if err != nil {
+		return err
+	}
+
 	// Create certs
-	tlsKey, tlsCrt, caCrt, err := certResources.CreateCerts(ctx, ServiceName, Namespace, time.Now().AddDate(1, 0, 0))
+	tlsKey, tlsCrt, caCrt, err := certResources.CreateCerts(ctx, svc, ns, time.Now().AddDate(1, 0, 0))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Fix #11
- Add rule for ValidatingWebhookConfiguration
- Set namespace as the current namespace the operator is running